### PR TITLE
implement basic auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ NOTE: Requires node.js
       --password  PostgreSQL password
       --raw       Enable raw SQL usage  [boolean]
       --cors      Enable CORS support   [boolean]
+      --secure    Enable Basic Auth support  [boolean]
+                  (configured via PG_BASIC_PASS and PG_BASIC_USER) 
       --help      Show this message
 
 ## API Usage

--- a/lib/basic_auth.coffee
+++ b/lib/basic_auth.coffee
@@ -1,0 +1,10 @@
+express = require('express')
+
+exports.secureAPI = express.basicAuth (user, pass) -> 
+    password = process.env.PG_BASIC_PASS
+    user = process.env.PG_BASIC_USER || 'pguser'
+    if (password == null || password == undefined) 
+      console.log("PG_BASIC_PASS env variable is missing....")
+      return false;
+    return user == user && pass == password
+

--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -4,28 +4,31 @@ optimist = require 'optimist'
 optimist.usage 'PostgreSQL HTTP API Server'
 optimist.options 'port',
     describe : 'HTTP Server port'
-    default : 3000
+    default : process.env.PG_PORT || 3000
 optimist.options 'dbhost',
     describe : 'PostgreSQL host'
-    default : 'localhost'
+    default : process.env.PG_HOST || 'localhost'
 optimist.options 'dbport',
     describe : 'PostgreSQL port'
-    default : 5432
+    default : process.env.PG_PORT || 5432
 optimist.options 'database',
     describe : 'PostgreSQL database'
-    default : process.env.USER
+    default : process.env.PG_USER || process.env.USER
 optimist.options 'user',
     describe : 'PostgreSQL username'
-    default : process.env.USER
+    default : process.env.PG_DB || process.env.USER
 optimist.options 'password',
     describe : 'PostgreSQL password'
+    default : process.env.PG_PASSWORD || null
 optimist.options 'raw',
     describe : 'Enable raw SQL usage'
 optimist.options 'cors',
     describe : 'Enable CORS support'
+optimist.options 'secure',
+    describe : 'Enable Basic Auth'    
 optimist.options 'help',
     describe : 'Show this message'
-argv = optimist.boolean('raw').boolean('cors')
+argv = optimist.boolean('raw').boolean('cors').boolean('secure')
     .demand(['port', 'dbhost', 'dbport', 'database', 'user'])
     .argv
 

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -1,4 +1,6 @@
 express = require 'express'
+auth = require './basic_auth'
+argv = require('optimist').argv
 
 class Server
   constructor: (app) ->
@@ -9,12 +11,14 @@ class Server
       app.configure ->
         app.use express.bodyParser()
         app.use express.methodOverride()
+        
       app.configure 'development', ->
       app.use express.errorHandler { dumpExceptions: true, showStack: true }
 
       app.configure 'production', ->
           app.use express.errorHandler()
-    
+      if argv.secure 
+        app.use auth.secureAPI
     @app = app
   
   # Initialize 


### PR DESCRIPTION
- expose basic auth support via `--secure`
- make the project a bit more cloud friendly by providing `process.env` variables for environment specific command line options
